### PR TITLE
fix: local node server choking on window refs

### DIFF
--- a/src/components/clientSideMemoHook.tsx
+++ b/src/components/clientSideMemoHook.tsx
@@ -1,0 +1,10 @@
+import { DependencyList, useEffect, useState } from "react"
+
+export const useClientSideMemo = <T,>(func: () => T, deps: DependencyList): T | null => {
+  const [value, setValue] = useState<T | null>(null)
+  Object.assign([], deps)
+  useEffect(() => {
+    setValue(func())
+  }, [func, ...deps])
+  return value
+}

--- a/src/components/mediaQueries.tsx
+++ b/src/components/mediaQueries.tsx
@@ -1,6 +1,7 @@
 'use client'
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
+import { useClientSideMemo } from "@/components/clientSideMemoHook";
 
 export enum MediaSizes {
   'xs' = 320,
@@ -15,22 +16,25 @@ export const getMinWidthQuery = (size: MediaSizes) => `(min-width: ${size}px)`
 export const getMaxWidthQuery = (size: MediaSizes) => `(max-width: ${size - 0.02}px)`
 
 export const useMediaQuery = (size: MediaSizes) => {
-  const matchMediaUp = useMemo(() => window.matchMedia(`(min-width: ${size}px)`), [size])
-  const matchMediaDown = useMemo(() => window.matchMedia(`(max-width: ${size - 0.02}px)`), [size])
-  const [matchesUp, setMatchesUp] = useState(() => matchMediaUp.matches);
-  const [matchesDown, setMatchesDown] = useState(() => matchMediaDown.matches);
+  const matchMediaUp = useClientSideMemo(() => window.matchMedia(`(min-width: ${size}px)`), [size])
+  const matchMediaDown = useClientSideMemo(() => window.matchMedia(`(max-width: ${size - 0.02}px)`), [size])
+  const [windowGreaterThan, setMatchesUp] = useState(() => matchMediaUp !== null ? matchMediaUp.matches : false);
+  const [windowLessThan, setMatchesDown] = useState(() => matchMediaDown !== null ? matchMediaDown.matches : false);
 
-  const listener = useCallback(() => {
+  const handleResize = useCallback(() => {
+    if (matchMediaUp === null || matchMediaDown === null) {
+      return
+    }
     setMatchesUp(matchMediaUp.matches)
     setMatchesDown(matchMediaDown.matches)
   }, [matchMediaUp, setMatchesUp, matchMediaDown, setMatchesDown])
   useEffect(() => {
-    window.addEventListener('resize', listener);
-    return () => window.removeEventListener('resize', listener);
-  }, [listener]);
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, [handleResize]);
 
   return {
-    matchesUp,
-    matchesDown
+    windowGreaterThan,
+    windowLessThan
   };
 };

--- a/src/components/pageLayout/Header/headerWrapper.tsx
+++ b/src/components/pageLayout/Header/headerWrapper.tsx
@@ -5,10 +5,10 @@ import { SiteHeader } from '@/components/pageLayout/Header/SiteHeader'
 
 export const HeaderWrapper = () => {
   const drawerState = useDrawerState(DrawerAnimationState.Closed)
-  const { matchesDown } = useMediaQuery(MediaSizes.sm)
+  const { windowLessThan } = useMediaQuery(MediaSizes.sm)
 
   let nav = <Nav onNavigation={drawerState.handleCloseDrawer} />
-  if (matchesDown) {
+  if (windowLessThan) {
     nav = <Drawer drawerState={drawerState}>{nav}</Drawer>
   }
   return <>


### PR DESCRIPTION
The node server was running the media queries hook but window does not exist in node land. This wraps the window refs with an effect that only fire after the component has mounted (which only happens in the browser). This still works as expected but prevents the console errors.